### PR TITLE
Fix CPU info

### DIFF
--- a/content/components/README.md
+++ b/content/components/README.md
@@ -16,8 +16,8 @@ MSM8227 = MSM8930 without 4G and HDMI and limited to 1GHz vs 1.2GHz
 A-Family chip. 
   
 32bits 28nm Qualcomm Snapdragon S4 Plus   
-2x 1GHz Krait 200 (armv7, neon 128bits, FPU VFPv3)  
-L2 cache 1MB / core  
+2x 1GHz Krait 200 (armv7, Cortex A15 compatible, neon 128bits, FPU VFPv4-D32)  
+L2 cache 1MB  
 L1 data cache 16KB / core  
 Hexagon QDSP6v4 500MHz  
 GPU Qualcomm Adreno 305  


### PR DESCRIPTION
Krait 200 has VFPv4-D32:
```
~ # lscpu
Architecture:             armv7l
  Byte Order:             Little Endian
CPU(s):                   2
  On-line CPU(s) list:    0,1
Vendor ID:                Qualcomm
  Model name:             Krait
    Model:                4
    Thread(s) per core:   1
    Core(s) per socket:   2
    Socket(s):            1
    Stepping:             0x1
    CPU(s) scaling MHz:   56%
    CPU max MHz:          972.0000
    CPU min MHz:          384.0000
    BogoMIPS:             13.50
    Flags:                half thumb fastmult vfp edsp neon vfpv3 tls vfpv4 idiv
                          a idivt vfpd32
```
and shared L2 between all cores (1MB for 2 cores, 2MB for 4 cores)